### PR TITLE
feat: migrate to sendgrid

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,8 +24,9 @@ jobs:
 
       - name: Update wrangler.toml
         run: |
-          sed -i 's/some-email@example.com/${{ secrets.EMAIL }}/g' wrangler.toml
+          sed -i 's/verified-sender@example.com/${{ secrets.SENDGRID_VERIFIED_SENDER }}/g' wrangler.toml
           sed -i 's/ALLOWED_ORIGINS=\[.*\]/ALLOWED_ORIGINS=${{ secrets.ALLOWED_ORIGINS }}/g' wrangler.toml
+          sed -i 's/SOME_SENDGRID_API_KEY/${{ secrets.SENDGRID_API_KEY }}/g' wrangler.toml
       
       - name: Install dependencies
         run: pnpm install
@@ -37,4 +38,5 @@ jobs:
         env:
           ALLOWED_ORIGINS: ${{ secrets.ALLOWED_ORIGINS }}
           EMAIL: ${{ secrets.EMAIL }}
+          SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
   

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,6 @@ jobs:
           apiToken: ${{ secrets.CF_API_TOKEN }}
         env:
           ALLOWED_ORIGINS: ${{ secrets.ALLOWED_ORIGINS }}
-          EMAIL: ${{ secrets.EMAIL }}
+          SENDGRID_VERIFIED_SENDER: ${{ secrets.SENDGRID_VERIFIED_SENDER }}
           SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
   

--- a/package.json
+++ b/package.json
@@ -16,6 +16,5 @@
     "wrangler": "^3.68.0"
   },
   "dependencies": {
-    "mimetext": "^3.0.24"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    dependencies:
-      mimetext:
-        specifier: ^3.0.24
-        version: 3.0.24
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: ^0.4.5
@@ -29,14 +25,6 @@ importers:
         version: 3.68.0(@cloudflare/workers-types@4.20240729.0)
 
 packages:
-
-  '@babel/runtime-corejs3@7.25.0':
-    resolution: {integrity: sha512-BOehWE7MgQ8W8Qn0CQnMtg2tHPHPulcS/5AVpFvs2KCK1ET+0WqZqPvnpRpFN81gYoFopdIEJX9Sgjw3ZBccPg==}
-    engines: {node: '>=6.9.0'}
-
-  '@babel/runtime@7.25.0':
-    resolution: {integrity: sha512-7dRy4DwXwtzBrPbZflqxnvfxLF8kdZXPkhymtDeFoFqE6ldzjQFgYTtYIFARcLEYDrqfBfYcZt1WqFxRoyC9Rw==}
-    engines: {node: '>=6.9.0'}
 
   '@cloudflare/kv-asset-handler@0.3.4':
     resolution: {integrity: sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==}
@@ -560,9 +548,6 @@ packages:
     resolution: {integrity: sha512-YZ3GUyn/o8gfKJlnlX7g7xq4gyO6OSuhGPKaaGssGB2qgDUS0gPgtTvoyZLTt9Ab6dC4hfc9dV5arkvc/OCmrw==}
     engines: {node: '>= 0.6'}
 
-  core-js-pure@3.38.0:
-    resolution: {integrity: sha512-8balb/HAXo06aHP58mZMtXgD8vcnXz9tUDePgqBgJgKdmTlMt+jw3ujqniuBDQXMvTzxnMpxHFeuSM3g1jWQuQ==}
-
   cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
@@ -688,9 +673,6 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
-  js-base64@3.7.7:
-    resolution: {integrity: sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==}
-
   js-tokens@9.0.0:
     resolution: {integrity: sha512-WriZw1luRMlmV3LGJaR6QOJjWwgLUTf89OwT2lUOyjX2dJGBwgmIkbcz+7WFZjrZM635JOIR517++e/67CP9dQ==}
 
@@ -710,21 +692,10 @@ packages:
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
-  mime-db@1.52.0:
-    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
-    engines: {node: '>= 0.6'}
-
-  mime-types@2.1.35:
-    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
-    engines: {node: '>= 0.6'}
-
   mime@3.0.0:
     resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
     engines: {node: '>=10.0.0'}
     hasBin: true
-
-  mimetext@3.0.24:
-    resolution: {integrity: sha512-UdG1KVfcxeEfo6el91lzFG2WLLTm8DxSK/rosxx5H2Pjla50+DSsjTgr9BRAfAkbQWaxvzcaTO+bHK5ZrdKdfA==}
 
   mimic-fn@4.0.0:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
@@ -820,9 +791,6 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
-
-  regenerator-runtime@0.14.1:
-    resolution: {integrity: sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==}
 
   resolve.exports@2.0.2:
     resolution: {integrity: sha512-X2UW6Nw3n/aMgDVy+0rSqgHlv39WZAlZrXCdnbyEiKm17DSqHX4MmQMaST3FbeWR5FTuRcUwYAziZajji0Y7mg==}
@@ -1056,15 +1024,6 @@ packages:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
 
 snapshots:
-
-  '@babel/runtime-corejs3@7.25.0':
-    dependencies:
-      core-js-pure: 3.38.0
-      regenerator-runtime: 0.14.1
-
-  '@babel/runtime@7.25.0':
-    dependencies:
-      regenerator-runtime: 0.14.1
 
   '@cloudflare/kv-asset-handler@0.3.4':
     dependencies:
@@ -1431,8 +1390,6 @@ snapshots:
 
   cookie@0.5.0: {}
 
-  core-js-pure@3.38.0: {}
-
   cross-spawn@7.0.3:
     dependencies:
       path-key: 3.1.1
@@ -1580,8 +1537,6 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  js-base64@3.7.7: {}
-
   js-tokens@9.0.0: {}
 
   local-pkg@0.5.0:
@@ -1603,20 +1558,7 @@ snapshots:
 
   merge-stream@2.0.0: {}
 
-  mime-db@1.52.0: {}
-
-  mime-types@2.1.35:
-    dependencies:
-      mime-db: 1.52.0
-
   mime@3.0.0: {}
-
-  mimetext@3.0.24:
-    dependencies:
-      '@babel/runtime': 7.25.0
-      '@babel/runtime-corejs3': 7.25.0
-      js-base64: 3.7.7
-      mime-types: 2.1.35
 
   mimic-fn@4.0.0: {}
 
@@ -1711,8 +1653,6 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
-
-  regenerator-runtime@0.14.1: {}
 
   resolve.exports@2.0.2: {}
 

--- a/src/mailing/models.ts
+++ b/src/mailing/models.ts
@@ -1,7 +1,0 @@
-type Success = 'success' | 'error'
-
-export interface EmailResponse {
-    success: Success
-    messageId?: string
-    error?: string
-}

--- a/src/mailing/sendgrid/client.ts
+++ b/src/mailing/sendgrid/client.ts
@@ -1,0 +1,42 @@
+import { EmailRequest, EmailResponse } from "./models";
+
+export async function sendEmail(
+    url: string,
+    apiKey: string,
+    from: string,
+    to: string,
+    content: string,
+    subject?: string,
+): Promise<EmailResponse> {
+
+    const emailRequest: EmailRequest = {
+        personalizations: [
+            {
+                to: [{ email: to }]
+            }
+        ],
+        from: { email: from },
+        subject,
+        content: [{
+            type: 'text/html',
+            value: content,
+        }]
+    }
+
+    const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${apiKey}`
+        },
+        body: JSON.stringify(emailRequest)
+    })
+
+    if (res.status == 202) {
+        return {
+            success: 'success'
+        }
+    }
+    throw Error(JSON.stringify(await res.text()))
+
+}

--- a/src/mailing/sendgrid/models.ts
+++ b/src/mailing/sendgrid/models.ts
@@ -1,0 +1,45 @@
+type Success = 'success' | 'error'
+
+export interface EmailResponse {
+    success: Success
+    error?: string
+}
+
+type AttachmentFileName = string
+type AttachmentType = 'applicationapplication/pdf'
+type AttachmentValue = string
+type ContentType = 'text/html'
+type ContentValue = string
+type Email = string // Might want to validate
+type Subject = string
+
+
+interface Recipient {
+    email: Email
+}
+
+type EmailTo = Recipient[]
+type EmailFrom = Recipient
+
+interface Personalization {
+    to: EmailTo
+}
+
+interface Content {
+    type: ContentType
+    value: ContentValue
+}
+
+interface Attachment {
+    type: AttachmentType
+    filename: AttachmentFileName
+    content: AttachmentValue
+}
+
+export interface EmailRequest {
+    personalizations: Personalization[]
+    from: EmailFrom
+    subject?: Subject
+    content: Content[]
+    attachments?: Attachment[]
+}

--- a/worker-configuration.d.ts
+++ b/worker-configuration.d.ts
@@ -3,6 +3,7 @@
 
 export interface Env {
 	ALLOWED_ORIGINS: string[];
-	EMAIL: string;
-	FORM_BINDING: SendEmail;
+	SENDGRID_URL: string
+	SENDGRID_API_KEY: string
+	SENDGRID_VERIFIED_SENDER: string
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,8 +3,9 @@ name = "mailing"
 main = "src/index.ts"
 compatibility_date = "2024-07-29"
 node_compat = true
-send_email = [{type = "send_email", name = "FORM_BINDING", destination_address = "some-email@example.com"}]
 
 [vars]
 ALLOWED_ORIGINS=['*']
-EMAIL="some-email@example.com"
+SENDGRID_API_KEY="SOME_SENDGRID_API_KEY"
+SENDGRID_URL="https://api.sendgrid.com/v3/mail/send"
+SENDGRID_VERIFIED_SENDER="verified-sender@example.com"


### PR DESCRIPTION
Use Sendgrid instead of `cloudflare:email` as the email routing requires to have a domain with them which is not possible for the time being.

This PR includes a client to interact with the Sendgrid API which is more tailored to what we need, avoiding to add new node dependencies which might not be supported by Cloudflare.